### PR TITLE
Exposed CampaignId on campaign class. Fixed spelling error.

### DIFF
--- a/createsend-dotnet/Campaign.cs
+++ b/createsend-dotnet/Campaign.cs
@@ -49,10 +49,10 @@ namespace createsend_dotnet
             HttpHelper.Delete(string.Format("/campaigns/{0}.json", _campaignID), null);
         }
 
-        public CampaignSumamry Summary()
+        public CampaignSummary Summary()
         {
             string json = HttpHelper.Get(string.Format("/campaigns/{0}/summary.json", _campaignID), null);
-            return JavaScriptConvert.DeserializeObject<CampaignSumamry>(json);
+            return JavaScriptConvert.DeserializeObject<CampaignSummary>(json);
         }
 
         public CampaignListsAndSegments ListsAndSegments()

--- a/createsend-dotnet/Models/Campaign.cs
+++ b/createsend-dotnet/Models/Campaign.cs
@@ -23,7 +23,7 @@ namespace createsend_dotnet
         public string PreviewURL { get; set; }
     }
 
-    public class CampaignSumamry
+    public class CampaignSummary
     {
         public int Recipients { get; set; }
         public int TotalOpened { get; set; }


### PR DESCRIPTION
I've made 2 tiny changes I think should be incorporated into the main repository.
1. I've exposed the `CampaignId` on the `Campaign` class. This is useful in circumstances where you do not have access to the campaign id that was used the fetch the object. For example:
   
   ```
   List<Campaign> campaigns = SomeHelper.GetAllCampaigns();
   
   foreach (var campaign in campaigns)
   {
       // try to do stuff, but have no idea what campaign we're dealing with
   }
   ```
   
   With my tiny tiny change, our classes become much more useful.
       List<Campaign> campaigns = SomeHelper.GetAllCampaigns();
   
   ```
   foreach (var campaign in campaigns)
   {
       // I once was blind, but now can see!
       Console.WriteLine("I'm checking on: " + campaign.CampaignId);
   }
   ```
2. I've renamed the class `CampaignSumamry` to `CampaignSummary`. Do I need to explain more?

Let me know what you think!
