### PR TITLE
Subscriber.cs changes

### DIFF
--- a/createsend-dotnet/Subscriber.cs
+++ b/createsend-dotnet/Subscriber.cs
@@ -71,7 +71,7 @@ namespace createsend_dotnet
                     ex.Data["ErrorResult"] = result;
                 }
             }
-            catch (Exception ex) { throw ex; }
+            catch (Exception ex) { throw; }
 
             return JavaScriptConvert.DeserializeObject<BulkImportResults>(json);
         }


### PR DESCRIPTION
The first commit is related to http://www.campaignmonitor.com/forums/viewtopic.php?id=5706 .. my application was "blowing up" because my list of subscribers had subscribers with invalid emails. Instead of causing my app to blow up, I should get a BulkImportResults object back with the details of the import results (including the emails with errors) when the exception being throw under the hood is are handled CreatesendExceptions.

Perhaps I jumped too quick doing my second commit in changing the 'throw ex;' to just 'throw;'. If you intention was to hide the underlying details than 'throw ex;' would do just that... but it will also hide any important information from the developer as to what's happening and give clues as to how to fix the problem they are experiencing.  If 'throw;' appears to be the correct goal then perhaps the entire 'catch (Exception ex) { throw; }' should just be removed since that's what would normally happen. The normal use of 'throw;' would be more in lines of:

catch (Exception ex)
{
// TODO: do something like rollback some changes or log the exception

// throw the exception with original stack trace to be caught latter down the stack line
throw;
}
