### PR TITLE
Support for multiple emails

### DIFF
--- a/createsend-dotnet/Campaign.cs
+++ b/createsend-dotnet/Campaign.cs
@@ -72,7 +72,7 @@ namespace createsend_dotnet
                 });
         }
 
-        public void Send(string confirmationEmail, DateTime sendDate)
+        public void Send(List<string> confirmationEmail, DateTime sendDate)
         {
             HttpHelper.Post<Dictionary<string, object>, string>(
                 AuthCredentials, 


### PR DESCRIPTION
This change is to be able to set multiple emails as confirmation email, 
witch is supported by Campaign Monitor (even though it's not in their 
documentation, I have an email saying that is supported the same as the 
`sendpreview` method).
 
I have taken the liberty to add `[Obsolete]` to this method and create a new 
that has the `List<string>` just like the `SendPreview` method to keep things 
in the same flow, I could have just replaced `confirmationEmail` with 
`confirmationEmail.Split(';')` but I wanted to make it the same as the existing code.
