### PR TITLE
Support for sending multiple confirmation emails when sending a draft campaign

### DIFF
--- a/createsend-dotnet/Campaign.cs
+++ b/createsend-dotnet/Campaign.cs
@@ -140,6 +140,29 @@ namespace createsend_dotnet
                 });
         }
 
+        /// <summary>
+        /// Schedules an existing draft campaign for sending to a custom date and time in the future.
+        /// </summary>
+        /// <param name="confirmationEmails">A maximum of five email addresses to which will be sent a confirmation email once the campaign has been sent.</param>
+        /// <param name="sendDate">The date the campaign should be scheduled to be sent.</param>
+        public void Send(List<string> confirmationEmails, DateTime sendDate)
+        {
+            HttpHelper.Post<Dictionary<string, object>, string>(
+                AuthCredentials, 
+                string.Format("/campaigns/{0}/send.json", CampaignID), 
+                null, 
+                new Dictionary<string, object>()
+                { 
+                    { "ConfirmationEmail", confirmationEmails }, 
+                    { "SendDate", sendDate.ToString("yyyy-MM-dd HH:mm:ss") } 
+                });
+        }
+        
+        /// <summary>
+        /// Schedules an existing draft campaign for sending to a custom date and time in the future.
+        /// </summary>
+        /// <param name="confirmationEmails">An email address to which which will be sent a confirmation email once the campaign has been sent.</param>
+        /// <param name="sendDate">The date the campaign should be scheduled to be sent.</param>
         public void Send(string confirmationEmail, DateTime sendDate)
         {
             HttpHelper.Post<Dictionary<string, object>, string>(


### PR DESCRIPTION
This was a feature I had made in August but now it's fully supported by Campaign Monitor API.

Campaign Monitor Api docs:
http://www.campaignmonitor.com/api/campaigns/#sending_a_campaign_preview

This feature is included in November 2012 Update of the API: 
https://www.campaignmonitor.com/forums/topic/7206/api-updates-for-november-2012/
