### PR TITLE
Use more specific appSettings key names

### DIFF
--- a/app.config.transform
+++ b/app.config.transform
@@ -1,6 +1,6 @@
 <configuration>
   <appSettings>
-    <add key="base_uri" value="https://api.createsend.com/api/v3.1" />
-    <add key="base_oauth_uri" value="https://api.createsend.com/oauth" />
+    <add key="createsend_api_base_uri" value="https://api.createsend.com/api/v3.1" />
+    <add key="createsend_api_base_oauth_uri" value="https://api.createsend.com/oauth" />
   </appSettings>
 </configuration>

--- a/createsend-dotnet/CreateSendOptions.cs
+++ b/createsend-dotnet/CreateSendOptions.cs
@@ -11,13 +11,13 @@ namespace createsend_dotnet
         static CreateSendOptions()
         {
             base_uri = string.IsNullOrEmpty(
-                ConfigurationManager.AppSettings["base_uri"]) ?
+                ConfigurationManager.AppSettings["createsend_api_base_uri"]) ?
                 "https://api.createsend.com/api/v3.1" :
-                ConfigurationManager.AppSettings["base_uri"];
+                ConfigurationManager.AppSettings["createsend_api_base_uri"];
             base_oauth_uri = string.IsNullOrEmpty(
-                ConfigurationManager.AppSettings["base_oauth_uri"]) ?
+                ConfigurationManager.AppSettings["createsend_api_base_oauth_uri"]) ?
                 "https://api.createsend.com/oauth" :
-                ConfigurationManager.AppSettings["base_oauth_uri"];
+                ConfigurationManager.AppSettings["createsend_api_base_oauth_uri"];
         }
 
         public static string BaseUri

--- a/createsend-dotnet/nuget/content/app.config.transform
+++ b/createsend-dotnet/nuget/content/app.config.transform
@@ -1,6 +1,6 @@
 <configuration>
   <appSettings>
-    <add key="base_uri" value="https://api.createsend.com/api/v3.1" />
-    <add key="base_oauth_uri" value="https://api.createsend.com/oauth" />
+    <add key="createsend_api_base_uri" value="https://api.createsend.com/api/v3.1" />
+    <add key="createsend_api_base_oauth_uri" value="https://api.createsend.com/oauth" />
   </appSettings>
 </configuration>

--- a/createsend-dotnet/nuget/content/web.config.transform
+++ b/createsend-dotnet/nuget/content/web.config.transform
@@ -1,6 +1,6 @@
 <configuration>
   <appSettings>
-    <add key="base_uri" value="https://api.createsend.com/api/v3.1" />
-    <add key="base_oauth_uri" value="https://api.createsend.com/oauth" />
+    <add key="createsend_api_base_uri" value="https://api.createsend.com/api/v3.1" />
+    <add key="createsend_api_base_oauth_uri" value="https://api.createsend.com/oauth" />
   </appSettings>
 </configuration>

--- a/web.config.transform
+++ b/web.config.transform
@@ -1,6 +1,6 @@
 <configuration>
   <appSettings>
-    <add key="base_uri" value="https://api.createsend.com/api/v3.1" />
-    <add key="base_oauth_uri" value="https://api.createsend.com/oauth" />
+    <add key="createsend_api_base_uri" value="https://api.createsend.com/api/v3.1" />
+    <add key="createsend_api_base_oauth_uri" value="https://api.createsend.com/oauth" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
To prevent potential collisions with other packages that may use the same appSettings key names, this changes the key names for the base URI and base OAuth URI configuration settings, but does not change the property names in the `CreateSendOptions` class.

This resolves #34.