### PR TITLE
`SentAt` field added to MessageListDetail class

### DIFF
--- a/createsend-dotnet/Transactional/MessageListDetail.cs
+++ b/createsend-dotnet/Transactional/MessageListDetail.cs
@@ -14,5 +14,6 @@ namespace createsend_dotnet.Transactional
         public long TotalOpens { get; set; }
         public long TotalClicks { get; set; }
         public bool CanBeResent { get; set; }
+        public DateTimeOffset SentAt { get; set; }
     }
 }


### PR DESCRIPTION
Not sure why it was missing in the first place, though after adding it, records returned are as shown in API page (https://www.campaignmonitor.com/api/transactional/#message-timeline)