### PR TITLE
CAS-216 Update API Wrapper to v3.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # createsend-dotnet history
 
+## v5.0.0 - 21 May, 2018
+
+* Update wrapper to API version 3.2
+** Add ConsentToTrack fields and includeTrackingPreference query string parameters
+
 ## v4.2.2 - 8 Oct, 2015
 
 * Actually upgraded the createsend package set to Nuget

--- a/Samples/List.cs
+++ b/Samples/List.cs
@@ -10,7 +10,7 @@ namespace Samples
         private AuthenticationDetails auth =
             new OAuthAuthenticationDetails(
                 "your access token", "your refresh token");
-        public string ListID = "your_list_id";
+        public string ListID { get; set; } = "your_list_id";
 
         public void GetDetails()
         {
@@ -126,7 +126,6 @@ namespace Samples
                         field.DataType,
                         field.VisibleInPreferenceCenter ? "" : "not "));
                 }
-
             }
             catch (CreatesendException ex)
             {
@@ -155,16 +154,20 @@ namespace Samples
                 allSubscribers.AddRange(firstPage.Results);
 
                 if (firstPage.NumberOfPages > 1)
+                {
                     for (int pageNumber = 2; pageNumber <= firstPage.NumberOfPages; pageNumber++)
                     {
                         PagedCollection<SubscriberDetail> subsequentPage = list.Active(new DateTime(1900, 1, 1), pageNumber, 50, "Email", "ASC", false);
                         allSubscribers.AddRange(subsequentPage.Results);
                     }
+                }
 
-                foreach(SubscriberDetail subscriberDetail in allSubscribers)
+                foreach (SubscriberDetail subscriberDetail in allSubscribers)
+                {
                     Console.WriteLine(string.Format(
                         "Subscriber with email address {0} reads mail with {1}.",
                         subscriberDetail.EmailAddress, subscriberDetail.ReadsEmailWith));
+                }
             }
             catch (CreatesendException ex)
             {

--- a/Samples/List.cs
+++ b/Samples/List.cs
@@ -149,15 +149,15 @@ namespace Samples
             {
                 List<SubscriberDetail> allSubscribers = new List<SubscriberDetail>();
 
-                //get the first page, with an old date to signify entire list
-                PagedCollection<SubscriberDetail> firstPage = list.Active(new DateTime(1900, 1, 1), 1, 50, "Email", "ASC");
+                // get the first page, with an old date to signify entire list
+                PagedCollection<SubscriberDetail> firstPage = list.Active(new DateTime(1900, 1, 1), 1, 50, "Email", "ASC", false);
 
                 allSubscribers.AddRange(firstPage.Results);
 
-                if(firstPage.NumberOfPages > 1)
+                if (firstPage.NumberOfPages > 1)
                     for (int pageNumber = 2; pageNumber <= firstPage.NumberOfPages; pageNumber++)
                     {
-                        PagedCollection<SubscriberDetail> subsequentPage = list.Active(new DateTime(1900, 1, 1), pageNumber, 50, "Email", "ASC");
+                        PagedCollection<SubscriberDetail> subsequentPage = list.Active(new DateTime(1900, 1, 1), pageNumber, 50, "Email", "ASC", false);
                         allSubscribers.AddRange(subsequentPage.Results);
                     }
 

--- a/Samples/List.cs
+++ b/Samples/List.cs
@@ -10,7 +10,7 @@ namespace Samples
         private AuthenticationDetails auth =
             new OAuthAuthenticationDetails(
                 "your access token", "your refresh token");
-        public string ListID { get; set; } = "your_list_id";
+        public string ListID = "your_list_id";
 
         public void GetDetails()
         {

--- a/Samples/Subscriber.cs
+++ b/Samples/Subscriber.cs
@@ -18,7 +18,7 @@ namespace Samples
 
             try
             {
-                string newSubscriberID = subscriber.Add("test@notarealdomain.com", "Test Name", null, false);
+                string newSubscriberID = subscriber.Add("test@notarealdomain.com", "Test Name", null, false, ConsentToTrack.Unchanged);
                 Console.WriteLine(newSubscriberID);
             }
             catch (CreatesendException ex)
@@ -44,7 +44,7 @@ namespace Samples
                 customFields.Add(new SubscriberCustomField() { Key = "CustomFieldKey", Value = "Value" });
                 customFields.Add(new SubscriberCustomField() { Key = "CustomFieldKey2", Value = "Value2" });
 
-                string newSubscriberID = subscriber.Add("test@notarealdomain.com", "Test Name", customFields, false);
+                string newSubscriberID = subscriber.Add("test@notarealdomain.com", "Test Name", customFields, false, ConsentToTrack.Unchanged);
                 Console.WriteLine(newSubscriberID);
             }
             catch (CreatesendException ex)
@@ -75,7 +75,7 @@ namespace Samples
                 customFields.Add(new SubscriberCustomField() { Key = "CustomFieldKey", Clear = true });
                 customFields.Add(new SubscriberCustomField() { Key = "CustomFieldKey2", Value = "Value2" });
 
-                subscriber.Update("test@notarealdomain.com", "new_address@notarealdomain.com", null, customFields, false);
+                subscriber.Update("test@notarealdomain.com", "new_address@notarealdomain.com", null, customFields, false, ConsentToTrack.Unchanged);
                 Console.WriteLine("Subscriber Updated successfully with new email: new_address@notarealdomain.com. Name was unchanged");
             }
             catch (CreatesendException ex)

--- a/createsend-dotnet.nuspec
+++ b/createsend-dotnet.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>campaignmonitor-api</id>
     <title>Campaign Monitor</title>
-    <version>4.2.2</version>
+    <version>5.0.0</version>
     <authors>Campaign Monitor</authors>
     <description>A .NET library for the Campaign Monitor API with enhancements for Transactional</description>
     <licenseUrl>http://opensource.org/licenses/mit-license</licenseUrl>

--- a/createsend-dotnet/Account.cs
+++ b/createsend-dotnet/Account.cs
@@ -5,7 +5,10 @@ namespace createsend_dotnet
 {
     public class Account : CreateSendBase
     {
-        public Account(AuthenticationDetails auth) : base(auth) { }
+        public Account(AuthenticationDetails auth) 
+            : base(auth)
+        {
+        }
 
         public string GetPrimaryContact()
         {

--- a/createsend-dotnet/AuthenticationDetails.cs
+++ b/createsend-dotnet/AuthenticationDetails.cs
@@ -4,13 +4,12 @@ using System.Text;
 
 namespace createsend_dotnet
 {
-    public abstract class AuthenticationDetails { }
+    public abstract class AuthenticationDetails
+    {
+    }
 
     public class OAuthAuthenticationDetails : AuthenticationDetails
     {
-        public string AccessToken { get; set; }
-        public string RefreshToken { get; set; }
-
         public OAuthAuthenticationDetails(
             string accessToken,
             string refreshToken)
@@ -18,6 +17,9 @@ namespace createsend_dotnet
             AccessToken = accessToken;
             RefreshToken = refreshToken;
         }
+
+        public string AccessToken { get; set; }
+        public string RefreshToken { get; set; }
     }
 
     public class ApiKeyAuthenticationDetails : AuthenticationDetails
@@ -32,9 +34,9 @@ namespace createsend_dotnet
 
     internal sealed class ClientApiKey : ApiKeyAuthenticationDetails
     {
-        public ClientApiKey(string apiKey) : base(apiKey)
+        public ClientApiKey(string apiKey) 
+            : base(apiKey)
         {
-            
         }
     }
 

--- a/createsend-dotnet/CreateSendOptions.cs
+++ b/createsend-dotnet/CreateSendOptions.cs
@@ -12,7 +12,7 @@ namespace createsend_dotnet
         {
             base_uri = string.IsNullOrEmpty(
                 ConfigurationManager.AppSettings["base_uri"]) ?
-                "https://api.createsend.com/api/v3.1" :
+                "https://api.createsend.com/api/v3.2" :
                 ConfigurationManager.AppSettings["base_uri"];
             base_oauth_uri = string.IsNullOrEmpty(
                 ConfigurationManager.AppSettings["base_oauth_uri"]) ?
@@ -36,7 +36,7 @@ namespace createsend_dotnet
         {
             get
             {
-                return "4.2.2";
+                return "5.0.0";
             }
         }
     }

--- a/createsend-dotnet/List.cs
+++ b/createsend-dotnet/List.cs
@@ -157,52 +157,52 @@ namespace createsend_dotnet
 
         public PagedCollection<SubscriberDetail> Active()
         {
-            return GenericPagedSubscriberGet("active", "", 1, 1000, "email", "asc");
+            return GenericPagedSubscriberGet("active", "", 1, 1000, "email", "asc", false);
         }
 
-        public PagedCollection<SubscriberDetail> Active(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection)
+        public PagedCollection<SubscriberDetail> Active(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
         {
-            return GenericPagedSubscriberGet("active", fromDate, page, pageSize, orderField, orderDirection);
+            return GenericPagedSubscriberGet("active", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Unconfirmed()
         {
-            return GenericPagedSubscriberGet("unconfirmed", "", 1, 1000, "email", "asc");
+            return GenericPagedSubscriberGet("unconfirmed", "", 1, 1000, "email", "asc", false);
         }
 
-        public PagedCollection<SubscriberDetail> Unconfirmed(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection)
+        public PagedCollection<SubscriberDetail> Unconfirmed(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
         {
-            return GenericPagedSubscriberGet("unconfirmed", fromDate, page, pageSize, orderField, orderDirection);
+            return GenericPagedSubscriberGet("unconfirmed", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Unsubscribed()
         {
-            return GenericPagedSubscriberGet("unsubscribed", "", 1, 1000, "email", "asc");
+            return GenericPagedSubscriberGet("unsubscribed", "", 1, 1000, "email", "asc", false);
         }
 
-        public PagedCollection<SubscriberDetail> Unsubscribed(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection)
+        public PagedCollection<SubscriberDetail> Unsubscribed(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
         {
-            return GenericPagedSubscriberGet("unsubscribed", fromDate, page, pageSize, orderField, orderDirection);
+            return GenericPagedSubscriberGet("unsubscribed", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Bounced()
         {
-            return GenericPagedSubscriberGet("bounced", "", 1, 1000, "email", "asc");
+            return GenericPagedSubscriberGet("bounced", "", 1, 1000, "email", "asc", false);
         }
 
-        public PagedCollection<SubscriberDetail> Bounced(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection)
+        public PagedCollection<SubscriberDetail> Bounced(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
         {
-            return GenericPagedSubscriberGet("bounced", fromDate, page, pageSize, orderField, orderDirection);
+            return GenericPagedSubscriberGet("bounced", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Deleted()
         {
-            return GenericPagedSubscriberGet("deleted", "", 1, 1000, "email", "asc");
+            return GenericPagedSubscriberGet("deleted", "", 1, 1000, "email", "asc", false);
         }
 
-        public PagedCollection<SubscriberDetail> Deleted(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection)
+        public PagedCollection<SubscriberDetail> Deleted(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
         {
-            return GenericPagedSubscriberGet("deleted", fromDate, page, pageSize, orderField, orderDirection);
+            return GenericPagedSubscriberGet("deleted", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         private PagedCollection<SubscriberDetail> GenericPagedSubscriberGet(
@@ -211,14 +211,15 @@ namespace createsend_dotnet
             int page,
             int pageSize,
             string orderField,
-            string orderDirection)
+            string orderDirection,
+            bool includeTrackingPreference)
         {
             return GenericPagedSubscriberGet(type,
                 fromDate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture), page, pageSize,
-                orderField, orderDirection);
+                orderField, orderDirection, includeTrackingPreference);
         }
 
-        private PagedCollection<SubscriberDetail> GenericPagedSubscriberGet(string type, string fromDate, int page, int pageSize, string orderField, string orderDirection)
+        private PagedCollection<SubscriberDetail> GenericPagedSubscriberGet(string type, string fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
         {
             NameValueCollection queryArguments = new NameValueCollection();
             queryArguments.Add("date", fromDate);
@@ -226,6 +227,7 @@ namespace createsend_dotnet
             queryArguments.Add("pagesize", pageSize.ToString());
             queryArguments.Add("orderfield", orderField);
             queryArguments.Add("orderdirection", orderDirection);
+            queryArguments.Add("includeTrackingPreference", includeTrackingPreference.ToString());
 
             return HttpGet<PagedCollection<SubscriberDetail>>(
                 string.Format("/lists/{0}/{1}.json", ListID, type), queryArguments);

--- a/createsend-dotnet/List.cs
+++ b/createsend-dotnet/List.cs
@@ -7,13 +7,13 @@ namespace createsend_dotnet
 {
     public class List : CreateSendBase
     {
-        public string ListID { get; set; }
-
         public List(AuthenticationDetails auth, string listID)
             : base(auth)
         {
             ListID = listID;
         }
+
+        public string ListID { get; set; }
 
         public static string Create(
             AuthenticationDetails auth,
@@ -86,10 +86,10 @@ namespace createsend_dotnet
         {
             return HttpPost<Dictionary<string, object>, string>(
                 string.Format("/lists/{0}/customfields.json", ListID), null,
-                new Dictionary<string, object>() 
-                { 
-                    { "FieldName", fieldName }, 
-                    { "DataType", dataType.ToString() }, 
+                new Dictionary<string, object>()
+                {
+                    { "FieldName", fieldName },
+                    { "DataType", dataType.ToString() },
                     { "Options", options },
                     { "VisibleInPreferenceCenter", visibleInPreferenceCenter }
                 });
@@ -101,9 +101,9 @@ namespace createsend_dotnet
             bool visibleInPreferenceCenter)
         {
             return HttpPut<Dictionary<string, object>, string>(
-                string.Format("/lists/{0}/customfields/{1}.json", 
+                string.Format("/lists/{0}/customfields/{1}.json",
                 ListID, System.Web.HttpUtility.UrlEncode(customFieldKey)), null,
-                new Dictionary<string, object>() 
+                new Dictionary<string, object>()
                 {
                     { "FieldName", fieldName },
                     { "VisibleInPreferenceCenter", visibleInPreferenceCenter }
@@ -113,7 +113,7 @@ namespace createsend_dotnet
         public void DeleteCustomField(string customFieldKey)
         {
             HttpDelete(
-                string.Format("/lists/{0}/customfields/{1}.json", 
+                string.Format("/lists/{0}/customfields/{1}.json",
                 ListID, System.Web.HttpUtility.UrlEncode(customFieldKey)), null);
         }
 
@@ -131,7 +131,8 @@ namespace createsend_dotnet
             HttpPut<object, string>(
                 string.Format("/lists/{0}/customfields/{1}/options.json",
                 ListID, System.Web.HttpUtility.UrlEncode(customFieldKey)), null,
-                new { 
+                new
+                {
                     KeepExistingOptions = keepExistingOptions,
                     Options = options
                 });
@@ -243,11 +244,11 @@ namespace createsend_dotnet
         {
             return HttpPost<Dictionary<string, object>, string>(
                 string.Format("/lists/{0}/webhooks.json", ListID), null,
-                new Dictionary<string, object>() 
-                { 
-                    { "Events", events }, 
-                    { "Url", url }, 
-                    { "PayloadFormat", payloadFormat } 
+                new Dictionary<string, object>()
+                {
+                    { "Events", events },
+                    { "Url", url },
+                    { "PayloadFormat", payloadFormat }
                 });
         }
 
@@ -256,8 +257,8 @@ namespace createsend_dotnet
             HttpGet<string, ErrorResult<WebhookTestErrorResult>>(
                 string.Format("/lists/{0}/webhooks/{1}/test.json",
                 ListID, System.Web.HttpUtility.UrlEncode(webhookID)), null);
-          
-            return true; //an exception will be thrown if there is a problem
+
+            return true; // an exception will be thrown if there is a problem
         }
 
         public void DeleteWebhook(string webhookID)

--- a/createsend-dotnet/List.cs
+++ b/createsend-dotnet/List.cs
@@ -156,9 +156,9 @@ namespace createsend_dotnet
                 string.Format("/lists/{0}/stats.json", ListID), null);
         }
 
-        public PagedCollection<SubscriberDetail> Active()
+        public PagedCollection<SubscriberDetail> Active(int page = 1, int pageSize = 1000, string orderField = "email", string orderDirection = "asc", bool includeTrackingPreference = false)
         {
-            return GenericPagedSubscriberGet("active", "", 1, 1000, "email", "asc", false);
+            return GenericPagedSubscriberGet("active", "", page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Active(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
@@ -166,9 +166,9 @@ namespace createsend_dotnet
             return GenericPagedSubscriberGet("active", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
-        public PagedCollection<SubscriberDetail> Unconfirmed()
+        public PagedCollection<SubscriberDetail> Unconfirmed(int page = 1, int pageSize = 1000, string orderField = "email", string orderDirection = "asc", bool includeTrackingPreference = false)
         {
-            return GenericPagedSubscriberGet("unconfirmed", "", 1, 1000, "email", "asc", false);
+            return GenericPagedSubscriberGet("unconfirmed", "", page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Unconfirmed(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
@@ -176,9 +176,9 @@ namespace createsend_dotnet
             return GenericPagedSubscriberGet("unconfirmed", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
-        public PagedCollection<SubscriberDetail> Unsubscribed()
+        public PagedCollection<SubscriberDetail> Unsubscribed(int page = 1, int pageSize = 1000, string orderField = "email", string orderDirection = "asc", bool includeTrackingPreference = false)
         {
-            return GenericPagedSubscriberGet("unsubscribed", "", 1, 1000, "email", "asc", false);
+            return GenericPagedSubscriberGet("unsubscribed", "", page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Unsubscribed(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
@@ -186,9 +186,9 @@ namespace createsend_dotnet
             return GenericPagedSubscriberGet("unsubscribed", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
-        public PagedCollection<SubscriberDetail> Bounced()
+        public PagedCollection<SubscriberDetail> Bounced(int page = 1, int pageSize = 1000, string orderField = "email", string orderDirection = "asc", bool includeTrackingPreference = false)
         {
-            return GenericPagedSubscriberGet("bounced", "", 1, 1000, "email", "asc", false);
+            return GenericPagedSubscriberGet("bounced", "", page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Bounced(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)
@@ -196,9 +196,9 @@ namespace createsend_dotnet
             return GenericPagedSubscriberGet("bounced", fromDate, page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
-        public PagedCollection<SubscriberDetail> Deleted()
+        public PagedCollection<SubscriberDetail> Deleted(int page = 1, int pageSize = 1000, string orderField = "email", string orderDirection = "asc", bool includeTrackingPreference = false)
         {
-            return GenericPagedSubscriberGet("deleted", "", 1, 1000, "email", "asc", false);
+            return GenericPagedSubscriberGet("deleted", "", page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Deleted(DateTime fromDate, int page, int pageSize, string orderField, string orderDirection, bool includeTrackingPreference)

--- a/createsend-dotnet/Models/Campaign.cs
+++ b/createsend-dotnet/Models/Campaign.cs
@@ -85,16 +85,22 @@ namespace createsend_dotnet
         public string CountryName { get; set; }
     }
 
-    public class CampaignOpenDetail : CampaignDetailWithGeoBase { }
+    public class CampaignOpenDetail : CampaignDetailWithGeoBase
+    {
+    }
 
     public class CampaignClickDetail : CampaignDetailWithGeoBase
     {
         public string URL { get; set; }
     }
 
-    public class CampaignUnsubscribeDetail : CampaignDetailBaseWithIPAddress { }
+    public class CampaignUnsubscribeDetail : CampaignDetailBaseWithIPAddress
+    {
+    }
 
-    public class CampaignSpamComplaint : CampaignDetailBase { }
+    public class CampaignSpamComplaint : CampaignDetailBase
+    {
+    }
 
     public class CampaignBounceDetail : CampaignDetailBaseWithIPAddress
     {

--- a/createsend-dotnet/Models/Client.cs
+++ b/createsend-dotnet/Models/Client.cs
@@ -13,7 +13,9 @@ namespace createsend_dotnet
         public string Name { get; set; }
     }
 
-    public class Clients : List<BasicClient> { }
+    public class Clients : List<BasicClient>
+    {
+    }
 
     public class ClientWithSettings
     {

--- a/createsend-dotnet/Models/ConsentToTrack.cs
+++ b/createsend-dotnet/Models/ConsentToTrack.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
-namespace createsend_dotnet.Models
+namespace createsend_dotnet
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ConsentToTrack
     {
         Unchanged = 0,

--- a/createsend-dotnet/Models/ConsentToTrack.cs
+++ b/createsend-dotnet/Models/ConsentToTrack.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace createsend_dotnet.Models
+{
+    public enum ConsentToTrack
+    {
+        Unchanged = 0,
+        Yes = 1,
+        No = 2
+    }
+}

--- a/createsend-dotnet/Models/CreatesendException.cs
+++ b/createsend-dotnet/Models/CreatesendException.cs
@@ -6,13 +6,22 @@ namespace createsend_dotnet
 {
     public class ExpiredOAuthTokenException : CreatesendException
     {
-        public ExpiredOAuthTokenException(string message) : base(message) { }
+        public ExpiredOAuthTokenException(string message)
+            : base(message)
+        {
+        }
     }
 
     public class CreatesendException : Exception
     {
-        public ErrorResult Error { get { return Data["ErrorResult"] as ErrorResult; } }
+        public ErrorResult Error
+        {
+            get { return Data["ErrorResult"] as ErrorResult; }
+        }
 
-        public CreatesendException(string message) : base (message) { }
+        public CreatesendException(string message)
+            : base(message)
+        {
+        }
     }
 }

--- a/createsend-dotnet/Models/List.cs
+++ b/createsend-dotnet/Models/List.cs
@@ -10,7 +10,9 @@ namespace createsend_dotnet
         public string Name { get; set; }
     }
 
-    public class Lists : List<BasicList> { }
+    public class Lists : List<BasicList>
+    {
+    }
 
     public class ListDetail
     {

--- a/createsend-dotnet/Models/Result.cs
+++ b/createsend-dotnet/Models/Result.cs
@@ -9,7 +9,10 @@ namespace createsend_dotnet
     [Serializable]
     public class ErrorResult<T> : ErrorResult
     {
-        public ErrorResult() : base() { }
+        public ErrorResult()
+            : base()
+        {
+        }
 
         public ErrorResult(ErrorResult errorResult)
         {

--- a/createsend-dotnet/Models/Segment.cs
+++ b/createsend-dotnet/Models/Segment.cs
@@ -11,7 +11,9 @@ namespace createsend_dotnet
         public string Title { get; set; }
     }
 
-    public class Segments : List<BasicSegment> { }
+    public class Segments : List<BasicSegment>
+    {
+    }
 
     public class SegmentDetail : BasicSegment
     {
@@ -19,7 +21,9 @@ namespace createsend_dotnet
         public SegmentRuleGroups RuleGroups { get; set; }
     }
 
-    public class SegmentRules : List<Rule> { }
+    public class SegmentRules : List<Rule>
+    {
+    }
 
     public class Rule
     {
@@ -27,14 +31,18 @@ namespace createsend_dotnet
         public string Clause { get; set; }
     }
 
-    public class SegmentRuleGroups : List<SegmentRuleGroup> { }
+    public class SegmentRuleGroups : List<SegmentRuleGroup>
+    {
+    }
 
     public class SegmentRuleGroup
     {
         public SegmentRules Rules { get; set; }
     }
 
-    public class RuleErrorResults : List<RuleErrorResult> { }
+    public class RuleErrorResults : List<RuleErrorResult>
+    {
+    }
 
     public class RuleErrorResult
     {
@@ -44,7 +52,9 @@ namespace createsend_dotnet
         public ClauseErrorResults ClauseResults { get; set; }
     }
 
-    public class ClauseErrorResults : List<ClauseErrorResult> { }
+    public class ClauseErrorResults : List<ClauseErrorResult>
+    {
+    }
 
     public class ClauseErrorResult
     {

--- a/createsend-dotnet/Models/Subscriber.cs
+++ b/createsend-dotnet/Models/Subscriber.cs
@@ -23,18 +23,23 @@ namespace createsend_dotnet
         public string ListID { get; set; }
     }
 
-    public class CampaignRecipients : List<CampaignRecipient> { }
+    public class CampaignRecipients : List<CampaignRecipient>
+    {
+    }
 
     public class SubscriberCustomField
     {
         public string Key { get; set; }
-        public string Value{ get ;set; }
+        public string Value { get; set; }
         public bool Clear { get; set; }
     }
 
     public class SubscriberDetail : BasicSubscriber
     {
-        public SubscriberDetail() : base() { }
+        public SubscriberDetail()
+            : base()
+        {
+        }
 
         public SubscriberDetail(
             string emailAddress,

--- a/createsend-dotnet/Models/Subscriber.cs
+++ b/createsend-dotnet/Models/Subscriber.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using createsend_dotnet.Models;
 
 namespace createsend_dotnet
 {
@@ -54,6 +53,6 @@ namespace createsend_dotnet
         public string Name { get; set; }
         public List<SubscriberCustomField> CustomFields { get; set; }
         public string ReadsEmailWith { get; set; }
-        public ConsentToTrack ConsentToTrack { get; set; }
+        public ConsentToTrack? ConsentToTrack { get; set; }
     }
 }

--- a/createsend-dotnet/Models/Subscriber.cs
+++ b/createsend-dotnet/Models/Subscriber.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using createsend_dotnet.Models;
 
 namespace createsend_dotnet
 {
@@ -48,5 +49,6 @@ namespace createsend_dotnet
         public string Name { get; set; }
         public List<SubscriberCustomField> CustomFields { get; set; }
         public string ReadsEmailWith { get; set; }
+        public ConsentToTrack ConsentToTrack { get; set; }
     }
 }

--- a/createsend-dotnet/Properties/AssemblyInfo.cs
+++ b/createsend-dotnet/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.2.0")]
-[assembly: AssemblyFileVersion("4.2.2.0")]
+[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]

--- a/createsend-dotnet/Segment.cs
+++ b/createsend-dotnet/Segment.cs
@@ -51,17 +51,18 @@ namespace createsend_dotnet
 
         public PagedCollection<SubscriberDetail> Subscribers()
         {
-            return Subscribers(1, 1000, "email", "asc");
+            return Subscribers(1, 1000, "email", "asc", false);
         }
 
         public PagedCollection<SubscriberDetail> Subscribers(
             int page,
             int pageSize,
             string orderField,
-            string orderDirection)
+            string orderDirection,
+            bool includeTrackingPreference)
         {
             return Subscribers("", page, pageSize, orderField,
-                orderDirection);
+                orderDirection, includeTrackingPreference);
         }
 
         public PagedCollection<SubscriberDetail> Subscribers(
@@ -69,10 +70,11 @@ namespace createsend_dotnet
             int page,
             int pageSize,
             string orderField,
-            string orderDirection)
+            string orderDirection,
+            bool includeTrackingPreference)
         {
             return Subscribers(fromDate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
-                page, pageSize, orderField, orderDirection);
+                page, pageSize, orderField, orderDirection, includeTrackingPreference);
         }
 
         private PagedCollection<SubscriberDetail> Subscribers(
@@ -80,7 +82,8 @@ namespace createsend_dotnet
             int page,
             int pageSize,
             string orderField,
-            string orderDirection)
+            string orderDirection,
+            bool includeTrackingPreference)
         {
             NameValueCollection queryArguments = new NameValueCollection();
             queryArguments.Add("date", fromDate);

--- a/createsend-dotnet/Segment.cs
+++ b/createsend-dotnet/Segment.cs
@@ -49,17 +49,12 @@ namespace createsend_dotnet
                 });
         }
 
-        public PagedCollection<SubscriberDetail> Subscribers()
-        {
-            return Subscribers(1, 1000, "email", "asc", false);
-        }
-
         public PagedCollection<SubscriberDetail> Subscribers(
-            int page,
-            int pageSize,
-            string orderField,
-            string orderDirection,
-            bool includeTrackingPreference)
+            int page = 1,
+            int pageSize = 1000,
+            string orderField = "email",
+            string orderDirection = "asc",
+            bool includeTrackingPreference = false)
         {
             return Subscribers("", page, pageSize, orderField,
                 orderDirection, includeTrackingPreference);
@@ -91,6 +86,7 @@ namespace createsend_dotnet
             queryArguments.Add("pagesize", pageSize.ToString());
             queryArguments.Add("orderfield", orderField);
             queryArguments.Add("orderdirection", orderDirection);
+            queryArguments.Add("includeTrackingPreference", includeTrackingPreference.ToString());
 
             return HttpGet<PagedCollection<SubscriberDetail>>(
                 string.Format("/segments/{0}/active.json", SegmentID), queryArguments);

--- a/createsend-dotnet/Segment.cs
+++ b/createsend-dotnet/Segment.cs
@@ -7,23 +7,23 @@ namespace createsend_dotnet
 {
     public class Segment : CreateSendBase
     {
-        public string SegmentID { get; set; }
-
         public Segment(AuthenticationDetails auth, string segmentID)
             : base(auth)
         {
             SegmentID = segmentID;
         }
 
+        public string SegmentID { get; set; }
+
         public static string Create(
             AuthenticationDetails auth, string listID, string title, SegmentRuleGroups ruleGroups)
         {
             return HttpHelper.Post<Dictionary<string, object>, string, ErrorResult<RuleErrorResults>>(
                 auth, string.Format("/segments/{0}.json", listID), null,
-                new Dictionary<string, object>() 
-                { 
-                    { "ListID", listID }, 
-                    { "Title", title }, 
+                new Dictionary<string, object>()
+                {
+                    { "ListID", listID },
+                    { "Title", title },
                     { "RuleGroups", ruleGroups }
                 });
         }
@@ -32,10 +32,10 @@ namespace createsend_dotnet
         {
             HttpPut<Dictionary<string, object>, string>(
                 string.Format("/segments/{0}.json", SegmentID), null,
-                new Dictionary<string, object>() 
-                { 
-                    { "Title", title }, 
-                    { "RuleGroups", ruleGroups } 
+                new Dictionary<string, object>()
+                {
+                    { "Title", title },
+                    { "RuleGroups", ruleGroups }
                 });
         }
 
@@ -43,9 +43,9 @@ namespace createsend_dotnet
         {
             HttpPost<Dictionary<string, object>, string>(
                 string.Format("/segments/{0}/rules.json", SegmentID), null,
-                new Dictionary<string, object>() 
-                { 
-                    { "Rules", ruleGroup.Rules } 
+                new Dictionary<string, object>()
+                {
+                    { "Rules", ruleGroup.Rules }
                 });
         }
 

--- a/createsend-dotnet/Subscriber.cs
+++ b/createsend-dotnet/Subscriber.cs
@@ -36,9 +36,10 @@ namespace createsend_dotnet
         }
 
         public string Add(string emailAddress, string name,
-            List<SubscriberCustomField> customFields, bool resubscribe)
+            List<SubscriberCustomField> customFields, bool resubscribe,
+            ConsentToTrack consentToTrack)
         {
-            return Add(emailAddress, name, customFields, resubscribe, false, ConsentToTrack.Unchanged);
+            return Add(emailAddress, name, customFields, resubscribe, false, consentToTrack);
         }
 
         public string Add(string emailAddress, string name,
@@ -60,10 +61,10 @@ namespace createsend_dotnet
 
         public void Update(string emailAddress, string newEmailAddress,
             string name, List<SubscriberCustomField> customFields,
-            bool resubscribe)
+            bool resubscribe, ConsentToTrack consentToTrack)
         {
             Update(emailAddress, newEmailAddress, name, customFields,
-                resubscribe, false, ConsentToTrack.Unchanged);
+                resubscribe, false, consentToTrack);
         }
 
         public void Update(string emailAddress, string newEmailAddress,

--- a/createsend-dotnet/Subscriber.cs
+++ b/createsend-dotnet/Subscriber.cs
@@ -6,13 +6,13 @@ namespace createsend_dotnet
 {
     public class Subscriber : CreateSendBase
     {
-        public string ListID { get; set; }
-
         public Subscriber(AuthenticationDetails auth, string listID)
             : base(auth)
         {
             ListID = listID;
         }
+
+        public string ListID { get; set; }
 
         public SubscriberDetail Get(string emailAddress, bool includeTrackingPreference)
         {
@@ -127,25 +127,23 @@ namespace createsend_dotnet
 
             return HttpPost<Dictionary<string, object>, BulkImportResults,
                 ErrorResult<BulkImportResults>>(
-                string.Format("/subscribers/{0}/import.json", ListID), null, 
-                new Dictionary<string, object>() 
-                { 
-                    { "Subscribers", reworkedSubscribers }, 
+                string.Format("/subscribers/{0}/import.json", ListID), null,
+                new Dictionary<string, object>()
+                {
+                    { "Subscribers", reworkedSubscribers },
                     { "Resubscribe", resubscribe },
-                    { "QueueSubscriptionBasedAutoResponders",
-                        queueSubscriptionBasedAutoResponders },
-                    { "RestartSubscriptionBasedAutoresponders",
-                        restartSubscriptionBasedAutoresponders }
+                    { "QueueSubscriptionBasedAutoResponders", queueSubscriptionBasedAutoResponders },
+                    { "RestartSubscriptionBasedAutoresponders", restartSubscriptionBasedAutoresponders }
                 });
         }
 
         public bool Unsubscribe(string emailAddress)
         {
             string result = HttpPost<Dictionary<string, string>, string>(
-                string.Format("/subscribers/{0}/unsubscribe.json", ListID), null, 
-                new Dictionary<string, string>() 
-                { 
-                    {"EmailAddress", emailAddress } 
+                string.Format("/subscribers/{0}/unsubscribe.json", ListID), null,
+                new Dictionary<string, string>()
+                {
+                    { "EmailAddress", emailAddress }
                 });
 
             return result != null;

--- a/createsend-dotnet/Subscriber.cs
+++ b/createsend-dotnet/Subscriber.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Specialized;
+using createsend_dotnet.Models;
 
 namespace createsend_dotnet
 {
@@ -13,10 +14,13 @@ namespace createsend_dotnet
             ListID = listID;
         }
 
-        public SubscriberDetail Get(string emailAddress)
+        public SubscriberDetail Get(string emailAddress, bool includeTrackingPreference)
         {
-            NameValueCollection queryArguments = new NameValueCollection();
-            queryArguments.Add("email", emailAddress);
+            NameValueCollection queryArguments = new NameValueCollection
+            {
+                { "email", emailAddress },
+                { "includeTrackingPreference", includeTrackingPreference.ToString() }
+            };
 
             return HttpGet<SubscriberDetail>(
                 string.Format("/subscribers/{0}.json", ListID), queryArguments);
@@ -35,23 +39,23 @@ namespace createsend_dotnet
         public string Add(string emailAddress, string name,
             List<SubscriberCustomField> customFields, bool resubscribe)
         {
-            return Add(emailAddress, name, customFields, resubscribe, false);
+            return Add(emailAddress, name, customFields, resubscribe, false, ConsentToTrack.Unchanged);
         }
 
         public string Add(string emailAddress, string name,
             List<SubscriberCustomField> customFields, bool resubscribe,
-            bool restartSubscriptionBasedAutoresponders)
+            bool restartSubscriptionBasedAutoresponders, ConsentToTrack consentToTrack)
         {
             return HttpPost<Dictionary<string, object>, string>(
                 string.Format("/subscribers/{0}.json", ListID), null,
-                new Dictionary<string, object>() 
-                { 
-                    { "EmailAddress", emailAddress }, 
-                    { "Name", name }, 
-                    { "CustomFields", customFields }, 
+                new Dictionary<string, object>()
+                {
+                    { "EmailAddress", emailAddress },
+                    { "Name", name },
+                    { "CustomFields", customFields },
                     { "Resubscribe", resubscribe },
-                    { "RestartSubscriptionBasedAutoresponders",
-                        restartSubscriptionBasedAutoresponders }
+                    { "RestartSubscriptionBasedAutoresponders", restartSubscriptionBasedAutoresponders },
+                    { "ConsentToTrack", consentToTrack }
                 });
         }
 
@@ -60,26 +64,26 @@ namespace createsend_dotnet
             bool resubscribe)
         {
             Update(emailAddress, newEmailAddress, name, customFields,
-                resubscribe, false);
+                resubscribe, false, ConsentToTrack.Unchanged);
         }
 
         public void Update(string emailAddress, string newEmailAddress,
-            string name, List<SubscriberCustomField> customFields,
-            bool resubscribe, bool restartSubscriptionBasedAutoresponders)
+            string name, List<SubscriberCustomField> customFields, bool resubscribe,
+            bool restartSubscriptionBasedAutoresponders, ConsentToTrack consentToTrack)
         {
             NameValueCollection queryArguments = new NameValueCollection();
             queryArguments.Add("email", emailAddress);
 
             HttpPut<Dictionary<string, object>, string>(
-                string.Format("/subscribers/{0}.json", ListID), queryArguments, 
-                new Dictionary<string, object>() 
-                { 
-                    { "EmailAddress", newEmailAddress }, 
-                    { "Name", name }, 
-                    { "CustomFields", customFields }, 
+                string.Format("/subscribers/{0}.json", ListID), queryArguments,
+                new Dictionary<string, object>()
+                {
+                    { "EmailAddress", newEmailAddress },
+                    { "Name", name },
+                    { "CustomFields", customFields },
                     { "Resubscribe", resubscribe },
-                    { "RestartSubscriptionBasedAutoresponders",
-                        restartSubscriptionBasedAutoresponders }
+                    { "RestartSubscriptionBasedAutoresponders", restartSubscriptionBasedAutoresponders },
+                    { "ConsentToTrack", consentToTrack }
                 });
         }
 
@@ -89,7 +93,7 @@ namespace createsend_dotnet
             queryArguments.Add("email", emailAddress);
             HttpDelete(string.Format("/subscribers/{0}.json", ListID), queryArguments);
         }
-        
+
         public BulkImportResults Import(List<SubscriberDetail> subscribers, bool resubscribe)
         {
             return Import(subscribers, resubscribe, false);
@@ -110,12 +114,14 @@ namespace createsend_dotnet
             foreach (SubscriberDetail subscriber in subscribers)
             {
                 Dictionary<string, object> subscriberWithoutDate =
-                    new Dictionary<string, object>() 
-                { 
-                    { "EmailAddress", subscriber.EmailAddress }, 
-                    { "Name", subscriber.Name }, 
-                    { "CustomFields", subscriber.CustomFields } 
+                    new Dictionary<string, object>()
+                {
+                    { "EmailAddress", subscriber.EmailAddress },
+                    { "Name", subscriber.Name },
+                    { "CustomFields", subscriber.CustomFields },
+                    { "ConsentToTrack", subscriber.ConsentToTrack }
                 };
+
                 reworkedSubscribers.Add(subscriberWithoutDate);
             }
 

--- a/createsend-dotnet/Subscriber.cs
+++ b/createsend-dotnet/Subscriber.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Specialized;
-using createsend_dotnet.Models;
 
 namespace createsend_dotnet
 {

--- a/createsend-dotnet/Transactional/ClassicEmail.cs
+++ b/createsend-dotnet/Transactional/ClassicEmail.cs
@@ -5,15 +5,15 @@ namespace createsend_dotnet.Transactional
 {
     public interface IClassicEmail
     {
-        RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null,
-            Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to);
+        RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, ConsentToTrack consentToTrack, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null,
+            Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to);
         RateLimited<ClassicEmailDetail[]> Groups();
     }
 
     public interface IAgencyClassicEmail : IClassicEmail
     {
-        RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null,
-            Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to);
+        RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, ConsentToTrack consentToTrack, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null,
+            Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to);
         RateLimited<ClassicEmailDetail[]> Groups(string clientId);
     }
 
@@ -24,12 +24,12 @@ namespace createsend_dotnet.Transactional
         {
         }
 
-        public RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
+        public RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, ConsentToTrack consentToTrack, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to)
         {
             return Send(new ClassicEmail(from, replyTo, to, cc, bcc, subject, html, text, images, attachments, trackOpens, trackClicks, inlineCss, @group, addRecipientsToListId, consentToTrack), this.CreateQueryString());
         }
 
-        public RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
+        public RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, ConsentToTrack consentToTrack, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to)
         {
             if (clientId == null)
             {

--- a/createsend-dotnet/Transactional/ClassicEmail.cs
+++ b/createsend-dotnet/Transactional/ClassicEmail.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Specialized;
-using createsend_dotnet.Models;
 
 namespace createsend_dotnet.Transactional
 {

--- a/createsend-dotnet/Transactional/ClassicEmail.cs
+++ b/createsend-dotnet/Transactional/ClassicEmail.cs
@@ -32,7 +32,10 @@ namespace createsend_dotnet.Transactional
 
         public RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
         {
-            if (clientId == null) throw new ArgumentNullException("clientId");
+            if (clientId == null)
+            {
+                throw new ArgumentNullException("clientId");
+            }
 
             return Send(new ClassicEmail(from, replyTo, to, cc, bcc, subject, html, text, images, attachments, trackOpens, trackClicks, inlineCss, @group, addRecipientsToListId, consentToTrack), this.CreateQueryString(clientId));
         }
@@ -49,7 +52,10 @@ namespace createsend_dotnet.Transactional
 
         public RateLimited<ClassicEmailDetail[]> Groups(string clientId)
         {
-            if (clientId == null) throw new ArgumentNullException("clientId");
+            if (clientId == null)
+            {
+                throw new ArgumentNullException("clientId");
+            }
 
             return Groups(this.CreateQueryString(clientId));
         }
@@ -62,23 +68,6 @@ namespace createsend_dotnet.Transactional
 
     internal class ClassicEmail
     {
-        public EmailAddress From { get; set; }
-        public EmailAddress ReplyTo { get; set; }
-        public EmailAddress[] To { get; set; }
-        public EmailAddress[] CC { get; set; }
-        public EmailAddress[] BCC { get; set; }
-        public string Subject { get; set; }
-        public string Html { get; set; }
-        public string Text { get; set; }
-        public Image[] Images { get; set; }
-        public Attachment[] Attachments { get; set; }
-        public bool TrackOpens { get; set; }
-        public bool TrackClicks { get; set; }
-        public bool InlineCss { get; set; }
-        public string Group { get; set; }
-        public string AddRecipientsToListId { get; set; }
-        public ConsentToTrack ConsentToTrack { get; set; }
-
         public ClassicEmail(EmailAddress from, EmailAddress replyTo, EmailAddress[] to, EmailAddress[] cc,
             EmailAddress[] bcc, string subject, string html, string text, Image[] images, Attachment[] attachments,
             bool trackOpens, bool trackClicks, bool inlineCss, string @group, string addRecipientsToListId, ConsentToTrack consentToTrack)
@@ -100,5 +89,22 @@ namespace createsend_dotnet.Transactional
             AddRecipientsToListId = addRecipientsToListId;
             ConsentToTrack = consentToTrack;
         }
+
+        public EmailAddress From { get; set; }
+        public EmailAddress ReplyTo { get; set; }
+        public EmailAddress[] To { get; set; }
+        public EmailAddress[] CC { get; set; }
+        public EmailAddress[] BCC { get; set; }
+        public string Subject { get; set; }
+        public string Html { get; set; }
+        public string Text { get; set; }
+        public Image[] Images { get; set; }
+        public Attachment[] Attachments { get; set; }
+        public bool TrackOpens { get; set; }
+        public bool TrackClicks { get; set; }
+        public bool InlineCss { get; set; }
+        public string Group { get; set; }
+        public string AddRecipientsToListId { get; set; }
+        public ConsentToTrack ConsentToTrack { get; set; }
     }
 }

--- a/createsend-dotnet/Transactional/ClassicEmail.cs
+++ b/createsend-dotnet/Transactional/ClassicEmail.cs
@@ -1,17 +1,20 @@
 ﻿using System;
 using System.Collections.Specialized;
+using createsend_dotnet.Models;
 
 namespace createsend_dotnet.Transactional
 {
     public interface IClassicEmail
     {
-        RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to);
+        RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null,
+            Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to);
         RateLimited<ClassicEmailDetail[]> Groups();
     }
 
     public interface IAgencyClassicEmail : IClassicEmail
     {
-        RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to);
+        RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null,
+            Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to);
         RateLimited<ClassicEmailDetail[]> Groups(string clientId);
     }
 
@@ -20,19 +23,18 @@ namespace createsend_dotnet.Transactional
         public ClassicEmailContext(AuthenticationDetails authenticationDetails, ICreateSendOptions options)
             : base(authenticationDetails, options)
         {
-
         }
 
-        public RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to)
+        public RateLimited<RecipientStatus[]> Send(EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
         {
-            return Send(new ClassicEmail(from, replyTo, to, cc, bcc, subject, html, text, images, attachments, trackOpens, trackClicks, inlineCss, @group, addRecipientsToListId), this.CreateQueryString());
+            return Send(new ClassicEmail(from, replyTo, to, cc, bcc, subject, html, text, images, attachments, trackOpens, trackClicks, inlineCss, @group, addRecipientsToListId, consentToTrack), this.CreateQueryString());
         }
 
-        public RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, params EmailAddress[] to)
+        public RateLimited<RecipientStatus[]> Send(string clientId, EmailAddress from, string subject, string html, string text, EmailAddress replyTo = null, EmailAddress[] cc = null, EmailAddress[] bcc = null, Image[] images = null, Attachment[] attachments = null, bool trackOpens = true, bool trackClicks = true, bool inlineCss = true, string @group = null, string addRecipientsToListId = null, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
         {
             if (clientId == null) throw new ArgumentNullException("clientId");
 
-            return Send(new ClassicEmail(from, replyTo, to, cc, bcc, subject, html, text, images, attachments, trackOpens, trackClicks, inlineCss, @group, addRecipientsToListId), this.CreateQueryString(clientId));
+            return Send(new ClassicEmail(from, replyTo, to, cc, bcc, subject, html, text, images, attachments, trackOpens, trackClicks, inlineCss, @group, addRecipientsToListId, consentToTrack), this.CreateQueryString(clientId));
         }
 
         private RateLimited<RecipientStatus[]> Send(ClassicEmail payload, NameValueCollection query)
@@ -75,10 +77,11 @@ namespace createsend_dotnet.Transactional
         public bool InlineCss { get; set; }
         public string Group { get; set; }
         public string AddRecipientsToListId { get; set; }
+        public ConsentToTrack ConsentToTrack { get; set; }
 
         public ClassicEmail(EmailAddress from, EmailAddress replyTo, EmailAddress[] to, EmailAddress[] cc,
             EmailAddress[] bcc, string subject, string html, string text, Image[] images, Attachment[] attachments,
-            bool trackOpens, bool trackClicks, bool inlineCss, string @group, string addRecipientsToListId)
+            bool trackOpens, bool trackClicks, bool inlineCss, string @group, string addRecipientsToListId, ConsentToTrack consentToTrack)
         {
             From = from;
             ReplyTo = replyTo;
@@ -95,6 +98,7 @@ namespace createsend_dotnet.Transactional
             InlineCss = inlineCss;
             Group = @group;
             AddRecipientsToListId = addRecipientsToListId;
+            ConsentToTrack = consentToTrack;
         }
     }
 }

--- a/createsend-dotnet/Transactional/MessageBuilder.cs
+++ b/createsend-dotnet/Transactional/MessageBuilder.cs
@@ -76,7 +76,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder From(EmailAddress from)
         {
-            if(from == null) throw new ArgumentNullException("from");
+            if (from == null)
+            {
+                throw new ArgumentNullException("from");
+            }
 
             this.from = from;
             return this;
@@ -84,7 +87,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder ReplyTo(EmailAddress replyTo)
         {
-            if(replyTo == null) throw new ArgumentNullException("replyTo");
+            if (replyTo == null)
+            {
+                throw new ArgumentNullException("replyTo");
+            }
 
             this.replyTo = replyTo;
             return this;
@@ -92,7 +98,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Subject(string subject)
         {
-            if(subject == null) throw new ArgumentNullException("subject");
+            if (subject == null)
+            {
+                throw new ArgumentNullException("subject");
+            }
 
             this.subject = subject;
             return this;
@@ -100,7 +109,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder To(EmailAddress to)
         {
-            if(to == null) throw new ArgumentNullException("to");
+            if (to == null)
+            {
+                throw new ArgumentNullException("to");
+            }
 
             this.to.Add(to);
             return this;
@@ -108,8 +120,14 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder To(EmailAddress[] to)
         {
-            if(to == null) throw new ArgumentNullException("to");
-            if(to.Length == 0) throw new ArgumentException("Cannot be empty", "to");
+            if (to == null)
+            {
+                throw new ArgumentNullException("to");
+            }
+            else if (to.Length == 0)
+            {
+                throw new ArgumentException("Cannot be empty", "to");
+            }
 
             this.to.AddRange(to);
             return this;
@@ -117,16 +135,26 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder CC(EmailAddress cc)
         {
-            if(cc == null) throw new ArgumentNullException("cc");
-            
+            if (cc == null)
+            {
+                throw new ArgumentNullException("cc");
+            }
+
             this.cc.Add(cc);
             return this;
         }
 
         public IMessageBuilder CC(EmailAddress[] cc)
         {
-            if(cc == null) throw new ArgumentNullException("cc");
-            if (cc.Length == 0) throw new ArgumentException("Cannot be empty", "cc");
+            if (cc == null)
+            {
+                throw new ArgumentNullException("cc");
+            }
+
+            if (cc.Length == 0)
+            {
+                throw new ArgumentException("Cannot be empty", "cc");
+            }
 
             this.cc.AddRange(cc);
             return this;
@@ -134,7 +162,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder BCC(EmailAddress bcc)
         {
-            if(bcc == null) throw new ArgumentNullException("bcc");
+            if (bcc == null)
+            {
+                throw new ArgumentNullException("bcc");
+            }
 
             this.bcc.Add(bcc);
             return this;
@@ -142,31 +173,37 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder BCC(EmailAddress[] bcc)
         {
-            if (bcc == null) throw new ArgumentNullException("bcc");
-            if (bcc.Length == 0) throw new ArgumentException("Cannot be empty", "bcc");
+            if (bcc == null)
+            {
+                throw new ArgumentNullException("bcc");
+            }
+            else if (bcc.Length == 0)
+            {
+                throw new ArgumentException("Cannot be empty", "bcc");
+            }
+
             this.bcc.AddRange(bcc);
             return this;
         }
 
         public IMessageBuilder Text(string text)
         {
-            if(text == null) throw new ArgumentNullException("text");
-
-            this.text = text;
+            this.text = text ?? throw new ArgumentNullException("text");
             return this;
         }
 
         public IMessageBuilder Html(string html)
         {
-            if(html == null) throw new ArgumentNullException("html");
-
-            this.html = html;
+            this.html = html ?? throw new ArgumentNullException("html");
             return this;
         }
 
         public IMessageBuilder Attachment(Attachment attachment)
         {
-            if(attachment == null) throw new ArgumentNullException("attachment");
+            if (attachment == null)
+            {
+                throw new ArgumentNullException("attachment");
+            }
 
             this.attachments.Add(attachment);
             return this;
@@ -174,8 +211,14 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Attachment(Attachment[] attachments)
         {
-            if(attachments == null) throw new ArgumentNullException("attachments");
-            if (attachments.Length == 0) throw new ArgumentException("Cannot be empty", "attachments");
+            if (attachments == null)
+            {
+                throw new ArgumentNullException("attachments");
+            }
+            else if (attachments.Length == 0)
+            {
+                throw new ArgumentException("Cannot be empty", "attachments");
+            }
 
             this.attachments.AddRange(attachments);
             return this;
@@ -183,7 +226,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Image(Image image)
         {
-            if(image == null) throw new ArgumentNullException("image");
+            if (image == null)
+            {
+                throw new ArgumentNullException("image");
+            }
 
             this.images.Add(image);
             return this;
@@ -191,8 +237,14 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Image(Image[] images)
         {
-            if(images == null) throw new ArgumentNullException("images");
-            if(images.Length == 0) throw new ArgumentException("Cannot be empty", "images");
+            if (images == null)
+            {
+                throw new ArgumentNullException("images");
+            }
+            else if (images.Length == 0)
+            {
+                throw new ArgumentException("Cannot be empty", "images");
+            }
 
             this.images.AddRange(images);
             return this;
@@ -200,7 +252,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Data(IDictionary<string, object> data)
         {
-            if(data == null) throw new ArgumentNullException("data");
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
 
             this.data = data;
             return this;
@@ -229,7 +284,10 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Group(string @group)
         {
-            if(@group == null) throw new ArgumentNullException("group");
+            if (@group == null)
+            {
+                throw new ArgumentNullException("group");
+            }
 
             this.@group = @group;
             return this;

--- a/createsend-dotnet/Transactional/MessageBuilder.cs
+++ b/createsend-dotnet/Transactional/MessageBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using createsend_dotnet.Models;
 
 namespace createsend_dotnet.Transactional
 {
@@ -59,7 +58,7 @@ namespace createsend_dotnet.Transactional
         private bool inlineCss = true;
         private string @group;
         private bool addRecipientsToList = true;
-        private ConsentToTrack consentToTrack = Models.ConsentToTrack.Unchanged;
+        private ConsentToTrack consentToTrack = createsend_dotnet.ConsentToTrack.Unchanged;
         private string listId;
 
         public MessageBuilder(SmartEmailContext smart, ClassicEmailContext classic)
@@ -188,13 +187,23 @@ namespace createsend_dotnet.Transactional
 
         public IMessageBuilder Text(string text)
         {
-            this.text = text ?? throw new ArgumentNullException("text");
+            if (text == null)
+            {
+                throw new ArgumentNullException("text");
+            }
+
+            this.text = text;
             return this;
         }
 
         public IMessageBuilder Html(string html)
         {
-            this.html = html ?? throw new ArgumentNullException("html");
+            if (html == null)
+            {
+                throw new ArgumentNullException("html");
+            }
+
+            this.html = html;
             return this;
         }
 

--- a/createsend-dotnet/Transactional/MessageBuilder.cs
+++ b/createsend-dotnet/Transactional/MessageBuilder.cs
@@ -58,7 +58,7 @@ namespace createsend_dotnet.Transactional
         private bool inlineCss = true;
         private string @group;
         private bool addRecipientsToList = true;
-        private ConsentToTrack consentToTrack = createsend_dotnet.ConsentToTrack.Unchanged;
+        private ConsentToTrack? consentToTrack;
         private string listId;
 
         public MessageBuilder(SmartEmailContext smart, ClassicEmailContext classic)
@@ -325,27 +325,41 @@ namespace createsend_dotnet.Transactional
 
         public RateLimited<RecipientStatus[]> Send()
         {
-            return classic.Send(from, subject, html, text, replyTo, cc.ToArray(), bcc.ToArray(), images.ToArray(),
-                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, consentToTrack, to.ToArray());
+            Validate();
+
+            return classic.Send(from, subject, html, text, consentToTrack.Value, replyTo, cc.ToArray(), bcc.ToArray(), images.ToArray(),
+                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, to.ToArray());
         }
 
         public RateLimited<RecipientStatus[]> Send(string clientId)
         {
-            return classic.Send(clientId, from, subject, html, text, replyTo, cc.ToArray(), bcc.ToArray(), images.ToArray(),
-                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, consentToTrack, to.ToArray());
+            Validate();
+
+            return classic.Send(clientId, from, subject, html, text, consentToTrack.Value, replyTo, cc.ToArray(), bcc.ToArray(), images.ToArray(),
+                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, to.ToArray());
         }
 
         public RateLimited<RecipientStatus[]> Send(Guid smartEmailId)
         {
+            Validate();
+
             return smart.Send(
                smartEmailId,
+               consentToTrack.Value,
                cc.ToArray(),
                bcc.ToArray(),
                attachments.ToArray(),
                data,
                addRecipientsToList,
-               consentToTrack,
                to.ToArray());
+        }
+
+        private void Validate()
+        {
+            if (!consentToTrack.HasValue)
+            {
+                throw new ArgumentException("Must specify a `Consent To Track` value");
+            }
         }
     }
 }

--- a/createsend-dotnet/Transactional/MessageBuilder.cs
+++ b/createsend-dotnet/Transactional/MessageBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using createsend_dotnet.Models;
 
 namespace createsend_dotnet.Transactional
 {
@@ -27,7 +28,8 @@ namespace createsend_dotnet.Transactional
         IMessageBuilder Group(string @group);
         IMessageBuilder AddRecipientsToList(bool addRecipientsToList);
         IMessageBuilder AddRecipientsToListId(string addRecipientsToListId);
-        
+        IMessageBuilder ConsentToTrack(ConsentToTrack consentToTrack);
+
         RateLimited<RecipientStatus[]> Send();
         RateLimited<RecipientStatus[]> Send(Guid smartEmailId);
     }
@@ -57,6 +59,7 @@ namespace createsend_dotnet.Transactional
         private bool inlineCss = true;
         private string @group;
         private bool addRecipientsToList = true;
+        private ConsentToTrack consentToTrack = Models.ConsentToTrack.Unchanged;
         private string listId;
 
         public MessageBuilder(SmartEmailContext smart, ClassicEmailContext classic)
@@ -246,18 +249,24 @@ namespace createsend_dotnet.Transactional
             return this;
         }
 
+        public IMessageBuilder ConsentToTrack(ConsentToTrack consentToTrack)
+        {
+            this.consentToTrack = consentToTrack;
+
+            return this;
+        }
+
         public RateLimited<RecipientStatus[]> Send()
         {
             return classic.Send(from, subject, html, text, replyTo, cc.ToArray(), bcc.ToArray(), images.ToArray(),
-                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, to.ToArray());
+                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, consentToTrack, to.ToArray());
         }
 
         public RateLimited<RecipientStatus[]> Send(string clientId)
         {
             return classic.Send(clientId, from, subject, html, text, replyTo, cc.ToArray(), bcc.ToArray(), images.ToArray(),
-                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, to.ToArray());
+                attachments.ToArray(), trackOpens, trackClicks, inlineCss, @group, listId, consentToTrack, to.ToArray());
         }
-
 
         public RateLimited<RecipientStatus[]> Send(Guid smartEmailId)
         {
@@ -268,6 +277,7 @@ namespace createsend_dotnet.Transactional
                attachments.ToArray(),
                data,
                addRecipientsToList,
+               consentToTrack,
                to.ToArray());
         }
     }

--- a/createsend-dotnet/Transactional/SmartEmail.cs
+++ b/createsend-dotnet/Transactional/SmartEmail.cs
@@ -6,8 +6,8 @@ namespace createsend_dotnet.Transactional
 {
     public interface ISmartEmail
     {
-        RateLimited<RecipientStatus[]> Send(Guid smartEmailId, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null,
-            IDictionary<string, object> data = null, bool addRecipientsToList = true, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to);
+        RateLimited<RecipientStatus[]> Send(Guid smartEmailId, ConsentToTrack consentToTrack, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null,
+            IDictionary<string, object> data = null, bool addRecipientsToList = true, params EmailAddress[] to);
         RateLimited<SmartEmailDetail> Details(Guid smartEmailId);
         RateLimited<SmartEmailListDetail[]> List(SmartEmailListStatus status = SmartEmailListStatus.All);
     }
@@ -24,8 +24,8 @@ namespace createsend_dotnet.Transactional
         {
         }
 
-        public RateLimited<RecipientStatus[]> Send(Guid smartEmailId, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null,
-            IDictionary<string, object> data = null, bool addRecipientsToList = true, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
+        public RateLimited<RecipientStatus[]> Send(Guid smartEmailId, ConsentToTrack consentToTrack, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null,
+            IDictionary<string, object> data = null, bool addRecipientsToList = true, params EmailAddress[] to)
         {
             return Send(smartEmailId, new SmartEmail(to, cc, bcc, attachments, data, addRecipientsToList, consentToTrack), new NameValueCollection());
         }

--- a/createsend-dotnet/Transactional/SmartEmail.cs
+++ b/createsend-dotnet/Transactional/SmartEmail.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using createsend_dotnet.Models;
 
 namespace createsend_dotnet.Transactional
 {
     public interface ISmartEmail
     {
-        RateLimited<RecipientStatus[]> Send(Guid smartEmailId, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null, IDictionary<string, object> data = null, bool addRecipientsToList = true, params EmailAddress[] to);
+        RateLimited<RecipientStatus[]> Send(Guid smartEmailId, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null,
+            IDictionary<string, object> data = null, bool addRecipientsToList = true, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to);
         RateLimited<SmartEmailDetail> Details(Guid smartEmailId);
         RateLimited<SmartEmailListDetail[]> List(SmartEmailListStatus status = SmartEmailListStatus.All);
     }
@@ -21,17 +23,17 @@ namespace createsend_dotnet.Transactional
         public SmartEmailContext(AuthenticationDetails authenticationDetails, ICreateSendOptions options)
             : base(authenticationDetails, options)
         {
-
         }
 
-        public RateLimited<RecipientStatus[]> Send(Guid smartEmailId, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null, IDictionary<string, object> data = null, bool addRecipientsToList = true, params EmailAddress[] to)
+        public RateLimited<RecipientStatus[]> Send(Guid smartEmailId, EmailAddress[] cc = null, EmailAddress[] bcc = null, Attachment[] attachments = null,
+            IDictionary<string, object> data = null, bool addRecipientsToList = true, ConsentToTrack consentToTrack = ConsentToTrack.Unchanged, params EmailAddress[] to)
         {
-            return Send(smartEmailId, new SmartEmail(to, cc, bcc, attachments, data, addRecipientsToList), new NameValueCollection());
+            return Send(smartEmailId, new SmartEmail(to, cc, bcc, attachments, data, addRecipientsToList, consentToTrack), new NameValueCollection());
         }
 
         private RateLimited<RecipientStatus[]> Send(Guid smartEmailId, SmartEmail payload, NameValueCollection query)
         {
-            return HttpPost<SmartEmail, RateLimited<RecipientStatus[]>>(String.Format("/transactional/smartemail/{0}/send", smartEmailId), query, payload);
+            return HttpPost<SmartEmail, RateLimited<RecipientStatus[]>>(string.Format("/transactional/smartemail/{0}/send", smartEmailId), query, payload);
         }
 
         public RateLimited<SmartEmailListDetail[]> List(SmartEmailListStatus status = SmartEmailListStatus.All)
@@ -58,7 +60,7 @@ namespace createsend_dotnet.Transactional
 
         private RateLimited<SmartEmailDetail> Details(Guid smartEmailId, NameValueCollection query)
         {
-            return HttpGet<RateLimited<SmartEmailDetail>>(String.Format("/transactional/smartemail/{0}", smartEmailId), query);
+            return HttpGet<RateLimited<SmartEmailDetail>>(string.Format("/transactional/smartemail/{0}", smartEmailId), query);
         }
 
         private NameValueCollection CreateQueryString(SmartEmailListStatus status, string clientId = null)
@@ -80,9 +82,10 @@ namespace createsend_dotnet.Transactional
         public Attachment[] Attachments { get; private set; }
         public IDictionary<string, object> Data { get; private set; }
         public bool AddRecipientsToList { get; private set; }
+        public ConsentToTrack ConsentToTrack { get; private set; }
 
         public SmartEmail(EmailAddress[] to, EmailAddress[] cc, EmailAddress[] bcc, Attachment[] attachments,
-            IDictionary<string, object> data, bool addRecipientsToList)
+            IDictionary<string, object> data, bool addRecipientsToList, ConsentToTrack consentToTrack)
         {
             To = to;
             CC = cc;
@@ -90,6 +93,7 @@ namespace createsend_dotnet.Transactional
             Attachments = attachments;
             Data = data;
             AddRecipientsToList = addRecipientsToList;
+            ConsentToTrack = ConsentToTrack;
         }
     }
 }

--- a/createsend-dotnet/Transactional/SmartEmail.cs
+++ b/createsend-dotnet/Transactional/SmartEmail.cs
@@ -43,7 +43,10 @@ namespace createsend_dotnet.Transactional
 
         public RateLimited<SmartEmailListDetail[]> List(string clientId, SmartEmailListStatus status = SmartEmailListStatus.All)
         {
-            if (clientId == null) throw new ArgumentNullException("clientId");
+            if (clientId == null)
+            {
+                throw new ArgumentNullException("clientId");
+            }
 
             return List(CreateQueryString(status, clientId));
         }
@@ -76,14 +79,6 @@ namespace createsend_dotnet.Transactional
 
     internal class SmartEmail
     {
-        public EmailAddress[] To { get; private set; }
-        public EmailAddress[] CC { get; private set; }
-        public EmailAddress[] BCC { get; private set; }
-        public Attachment[] Attachments { get; private set; }
-        public IDictionary<string, object> Data { get; private set; }
-        public bool AddRecipientsToList { get; private set; }
-        public ConsentToTrack ConsentToTrack { get; private set; }
-
         public SmartEmail(EmailAddress[] to, EmailAddress[] cc, EmailAddress[] bcc, Attachment[] attachments,
             IDictionary<string, object> data, bool addRecipientsToList, ConsentToTrack consentToTrack)
         {
@@ -95,5 +90,13 @@ namespace createsend_dotnet.Transactional
             AddRecipientsToList = addRecipientsToList;
             ConsentToTrack = ConsentToTrack;
         }
+
+        public EmailAddress[] To { get; private set; }
+        public EmailAddress[] CC { get; private set; }
+        public EmailAddress[] BCC { get; private set; }
+        public Attachment[] Attachments { get; private set; }
+        public IDictionary<string, object> Data { get; private set; }
+        public bool AddRecipientsToList { get; private set; }
+        public ConsentToTrack ConsentToTrack { get; private set; }
     }
 }

--- a/createsend-dotnet/Transactional/SmartEmail.cs
+++ b/createsend-dotnet/Transactional/SmartEmail.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using createsend_dotnet.Models;
 
 namespace createsend_dotnet.Transactional
 {
@@ -88,7 +87,7 @@ namespace createsend_dotnet.Transactional
             Attachments = attachments;
             Data = data;
             AddRecipientsToList = addRecipientsToList;
-            ConsentToTrack = ConsentToTrack;
+            ConsentToTrack = consentToTrack;
         }
 
         public EmailAddress[] To { get; private set; }

--- a/createsend-dotnet/Transactional/Transactional.cs
+++ b/createsend-dotnet/Transactional/Transactional.cs
@@ -6,16 +6,16 @@ namespace createsend_dotnet.Transactional
     {
         IClassicEmail ClassicEmail { get; }
         ISmartEmail SmartEmail { get; }
-        IMessageBuilder MessageBuilder();
         IMessages Messages { get; }
+        IMessageBuilder MessageBuilder();
     }
 
     public interface IAgencyTransactional : IAgencyStatistics
     {
         IAgencyClassicEmail ClassicEmail { get; }
         IAgencySmartEmail SmartEmail { get; }
-        IAgencyMessageBuilder MessageBuilder();
         IAgencyMessages Messages { get; }
+        IAgencyMessageBuilder MessageBuilder();
     }
 
     internal class TransactionalContext : ITransactional, IAgencyTransactional
@@ -52,7 +52,7 @@ namespace createsend_dotnet.Transactional
         {
             get { return smartEmail; }
         }
-        
+
         IMessages ITransactional.Messages
         {
             get { return messages; }

--- a/createsend-dotnet/createsend-dotnet.csproj
+++ b/createsend-dotnet/createsend-dotnet.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Models\BillingDetails.cs" />
     <Compile Include="Models\Campaign.cs" />
     <Compile Include="Models\Administrator.cs" />
+    <Compile Include="Models\ConsentToTrack.cs" />
     <Compile Include="Models\CreatesendException.cs" />
     <Compile Include="Models\Client.cs" />
     <Compile Include="HttpHelper.cs" />

--- a/createsend-dotnet/createsend-dotnet.net20.csproj
+++ b/createsend-dotnet/createsend-dotnet.net20.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Models\Administrator.cs" />
     <Compile Include="Models\BillingDetails.cs" />
     <Compile Include="Models\Campaign.cs" />
+    <Compile Include="Models\ConsentToTrack.cs" />
     <Compile Include="Models\CreatesendException.cs" />
     <Compile Include="Models\Client.cs" />
     <Compile Include="HttpHelper.cs" />

--- a/createsend-dotnet/createsend-dotnet.net35.csproj
+++ b/createsend-dotnet/createsend-dotnet.net35.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Models\Administrator.cs" />
     <Compile Include="Models\BillingDetails.cs" />
     <Compile Include="Models\Campaign.cs" />
+    <Compile Include="Models\ConsentToTrack.cs" />
     <Compile Include="Models\CreatesendException.cs" />
     <Compile Include="Models\Client.cs" />
     <Compile Include="HttpHelper.cs" />


### PR DESCRIPTION
# Get single subscriber ✓
- Api returns empty string for Unknown
	- Maps Unknown ConsentToTrack property on SubscriberDetail to null
	
# Add single subscriber ✓
- Default value = Unchanged

# Get list subscribers ✓
- Active
- Unsubscribed
- Deleted
- Bounced
- Unconfirmed

# Get segment subscribers ✓

# Bulk import ✓
- Not setting consent to track will cause exception on response

# Smart transactional ✓

# Classic transactional ✓