### PR TITLE
Remove MarkupOnDesignSpamTest property

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # createsend-dotnet history
 
+
+## v6.0.1 - 12 March, 2025
+
+* Removed now redundant parameter ```markupOnDesignSpamTest``` from method Client.SetPAYGBilling
+
 ## v6.0.1 - 6 April, 2023
 
 * Adding support for returning MobileNumber and ConsentToSendSms for each subscriber

--- a/createsend-dotnet.nuspec
+++ b/createsend-dotnet.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>campaignmonitor-api</id>
     <title>Campaign Monitor</title>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <authors>Campaign Monitor</authors>
     <description>A .NET library for the Campaign Monitor API with enhancements for Transactional</description>
     <licenseUrl>http://opensource.org/licenses/mit-license</licenseUrl>

--- a/createsend-dotnet/Client.cs
+++ b/createsend-dotnet/Client.cs
@@ -124,7 +124,7 @@ namespace createsend_dotnet
                 });
         }
 
-        public void SetPAYGBilling(string currency, bool clientPays, bool canPurchaseCredits, int markupPercentage, decimal markupOnDelivery, decimal markupPerRecipient, decimal markupOnDesignSpamTest)
+        public void SetPAYGBilling(string currency, bool clientPays, bool canPurchaseCredits, int markupPercentage, decimal markupOnDelivery, decimal markupPerRecipient)
         {
             HttpPut<BillingOptions, string>(
                 string.Format("/clients/{0}/setpaygbilling.json", ClientID), null,
@@ -136,7 +136,6 @@ namespace createsend_dotnet
                     MarkupPercentage = markupPercentage,
                     MarkupOnDelivery = markupOnDelivery,
                     MarkupPerRecipient = markupPerRecipient,
-                    MarkupOnDesignSpamTest = markupOnDesignSpamTest
                 });
         }
 

--- a/createsend-dotnet/CreateSendOptions.cs
+++ b/createsend-dotnet/CreateSendOptions.cs
@@ -36,7 +36,7 @@ namespace createsend_dotnet
         {
             get
             {
-                return "6.0.1";
+                return "6.0.2";
             }
         }
     }

--- a/createsend-dotnet/Models/Client.cs
+++ b/createsend-dotnet/Models/Client.cs
@@ -44,7 +44,6 @@ namespace createsend_dotnet
         public int Credits { get; set; }
         public decimal? MarkupOnDelivery { get; set; }
         public decimal? MarkupPerRecipient { get; set; }
-        public decimal? MarkupOnDesignSpamTest { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         public MonthlyScheme? MonthlyScheme { get; set; }
     }

--- a/createsend-dotnet/Properties/AssemblyInfo.cs
+++ b/createsend-dotnet/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.1.0")]
-[assembly: AssemblyFileVersion("6.0.1.0")]
+[assembly: AssemblyVersion("6.0.2.0")]
+[assembly: AssemblyFileVersion("6.0.2.0")]


### PR DESCRIPTION
This PR removes the redudant variable MarkupOnDesignSpamTest 

I do not have access Visual Studio 2019 and thus cannot build the solution `createsend-dotnet.standard20.sln` as Visual Studio 2022 can't build .NET 4 projects, but I don't see why it wouldn't build.